### PR TITLE
fix(nginx): Add health location to nginx host

### DIFF
--- a/charts/nginx/Chart.yaml
+++ b/charts/nginx/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/nginx/README.md
+++ b/charts/nginx/README.md
@@ -1,6 +1,6 @@
 # nginx
 
-![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.25.0](https://img.shields.io/badge/AppVersion-1.25.0-informational?style=flat-square)
+![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.25.0](https://img.shields.io/badge/AppVersion-1.25.0-informational?style=flat-square)
 
 This is a very simple NGINX chart, that can deploy a webserver serving a site config. Its main use case is to do more complex proxy passing than an ingress could handle.
 

--- a/charts/nginx/templates/configmap.yaml
+++ b/charts/nginx/templates/configmap.yaml
@@ -7,7 +7,13 @@ data:
     server {
       listen {{ .Values.health.port }};
       server_name localhost;
+      location / {
+        access_log off;
+        add_header 'Content-Type' 'application/json';
+        return 200 '{"status":"UP"}';
+      }
       location /metrics {
+        access_log off;
         stub_status;
         allow 127.0.0.1;
         deny all;


### PR DESCRIPTION
Adds the requisite healthcheck locations to the nginx host, so that default liveness and readiness work. Could easily be overridden if we had for example a liveness and readiness in magnolia.