### PR TITLE
fix(nginx): Revert to old config hash generation

### DIFF
--- a/charts/nginx/templates/configmap.yaml
+++ b/charts/nginx/templates/configmap.yaml
@@ -1,4 +1,3 @@
-{{- define "nginx.siteConfig" -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -22,4 +21,3 @@ data:
     }
   user_site.conf: |-
   {{ .Values.siteConfig | nindent 4}}
-{{- end -}}

--- a/charts/nginx/templates/deployment.yaml
+++ b/charts/nginx/templates/deployment.yaml
@@ -18,7 +18,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- if .Values.siteConfig }}
-        checksum/server-block-configuration: {{ include ("nginx.siteConfig") . | sha256sum }}
+        checksum/server-block-configuration: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- end }}
         {{- if .Values.metrics.enabled }}
         prometheus.io/scrape: "true"


### PR DESCRIPTION
The new one made it so that the configmap wasn't applied in K8s anymore.