### PR TITLE
fix(nginx):Switch back to nindent

### DIFF
--- a/charts/nginx/templates/configmap-sites.yaml
+++ b/charts/nginx/templates/configmap-sites.yaml
@@ -20,4 +20,4 @@ data:
       }
     }
   user_site.conf: |-
-  {{ .Values.siteConfig | indent 4}}
+  {{ .Values.siteConfig | nindent 4}}

--- a/charts/nginx/templates/configmap.yaml
+++ b/charts/nginx/templates/configmap.yaml
@@ -4,5 +4,5 @@ metadata:
   name: nginx-config
 data:
   nginx.conf: |-
-  {{ .Values.nginxConfig | indent 4 }}
+  {{ .Values.nginxConfig | nindent 4 }}
 


### PR DESCRIPTION
For some reason the configs don't work when there isn't a newline at the begin of the template