### PR TITLE
fix breaking docu-bot on no readme changes

### DIFF
--- a/.github/workflows/generate-helm-docs.yml
+++ b/.github/workflows/generate-helm-docs.yml
@@ -25,5 +25,4 @@ jobs:
           sudo dpkg -i /helm-doc.deb
           helm-docs
           git add **/README.md
-          git commit -m "ci(docu-bot): Generate helm docs"
-          git push
+          git diff --staged --quiet || (git commit -am "ci(docu-bot): generate helm docs" && git push)


### PR DESCRIPTION
docu bot broke when there were no readme changes because git commit and git push both exit with a code other than 0 when there is nothing to commit or to push. Prepending `git diff` solves this so that the commands only get called if there is a diff