### PR TITLE
feat: Allow service annotations for nginx

### DIFF
--- a/charts/nginx/Chart.yaml
+++ b/charts/nginx/Chart.yaml
@@ -1,6 +1,7 @@
 apiVersion: v2
 name: nginx
-description: This is a very simple NGINX chart, that can deploy a webserver serving
+description:
+  This is a very simple NGINX chart, that can deploy a webserver serving
   a site config. Its main use case is to do more complex proxy passing than an
   ingress could handle.
 
@@ -17,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.5
+version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/nginx/README.md
+++ b/charts/nginx/README.md
@@ -1,6 +1,6 @@
 # nginx
 
-![Version: 0.2.5](https://img.shields.io/badge/Version-0.2.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.25.0](https://img.shields.io/badge/AppVersion-1.25.0-informational?style=flat-square)
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.25.0](https://img.shields.io/badge/AppVersion-1.25.0-informational?style=flat-square)
 
 This is a very simple NGINX chart, that can deploy a webserver serving a site config. Its main use case is to do more complex proxy passing than an ingress could handle.
 
@@ -39,7 +39,12 @@ This is a very simple NGINX chart, that can deploy a webserver serving a site co
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
 | securityContext | object | `{}` |  |
-| service.port | int | `80` |  |
+| service.annotations | object | `{}` |  |
+| service.loadBalancerClass | string | `nil` |  |
+| service.ports[0].name | string | `"http"` |  |
+| service.ports[0].protocol | string | `"TCP"` |  |
+| service.ports[0].sourcePort | int | `80` |  |
+| service.ports[0].targetPort | string | `"http"` |  |
 | service.type | string | `"ClusterIP"` |  |
 | tolerations | list | `[]` |  |
 

--- a/charts/nginx/templates/service.yaml
+++ b/charts/nginx/templates/service.yaml
@@ -4,12 +4,21 @@ metadata:
   name: {{ include "nginx.fullname" . }}
   labels:
     {{- include "nginx.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if .Values.service.loadBalancerClass }}
+  loadBalancerClass: {{.Values.service.loadBalancerClass}}
+  {{- end }}
   ports:
-    - port: {{ .Values.service.port }}
-      targetPort: http
-      protocol: TCP
-      name: http
+  {{ for port in .Values.service.ports }}
+    - port: {{ .sourcePort }}
+      targetPort: {{ .targetPort }}
+      protocol: {{ .protocol }}
+      name: {{ port.name }}
+  {{ end }}
   selector:
     {{- include "nginx.selectorLabels" . | nindent 4 }}

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -12,10 +12,12 @@ fullnameOverride: ""
 
 podAnnotations: {}
 
-podSecurityContext: {}
+podSecurityContext:
+  {}
   # fsGroup: 2000
 
-securityContext: {}
+securityContext:
+  {}
   # capabilities:
   #   drop:
   #   - ALL
@@ -24,8 +26,14 @@ securityContext: {}
   # runAsUser: 1000
 
 service:
+  loadBalancerClass:
   type: ClusterIP
-  port: 80
+  ports:
+    - sourcePort: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  annotations: {}
 
 health:
   name: healthcheck
@@ -34,7 +42,8 @@ health:
 ingress:
   enabled: false
   className: ""
-  annotations: {}
+  annotations:
+    {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:


### PR DESCRIPTION
Adds capability for service annotations to the nginx helm chart. Also allows definition of multiple ports for one service.

This is a breaking change, as the port format changed.